### PR TITLE
test: add more tests for promisify and wait-resolveable utils

### DIFF
--- a/dist/es/utils.js
+++ b/dist/es/utils.js
@@ -1,8 +1,7 @@
 export function oneOfArrayNotInString(stringAr, str) {
-    var foundNotInString = stringAr.find(function (sub) {
+    return !!stringAr.find(function (sub) {
         return !str.includes(sub);
     });
-    if (foundNotInString) return true;else return false;
 }
 
 export var TIMEOUT_MAX = 2147483647;

--- a/dist/lib/utils.js
+++ b/dist/lib/utils.js
@@ -6,10 +6,9 @@ Object.defineProperty(exports, "__esModule", {
 exports.oneOfArrayNotInString = oneOfArrayNotInString;
 exports.ensureInSetTimeoutLimit = ensureInSetTimeoutLimit;
 function oneOfArrayNotInString(stringAr, str) {
-    var foundNotInString = stringAr.find(function (sub) {
+    return !!stringAr.find(function (sub) {
         return !str.includes(sub);
     });
-    if (foundNotInString) return true;else return false;
 }
 
 var TIMEOUT_MAX = exports.TIMEOUT_MAX = 2147483647;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,5 @@
 export function oneOfArrayNotInString(stringAr, str) {
-    const foundNotInString = stringAr.find(sub => !str.includes(sub));
-    if (foundNotInString) return true;
-    else return false;
+    return !!stringAr.find(sub => !str.includes(sub));
 }
 
 

--- a/test/promisify.test.js
+++ b/test/promisify.test.js
@@ -11,4 +11,9 @@ describe('promisify.test.js', () => {
         const ret = AsyncTestUtil.promisify(undefined);
         assert.ok(ret instanceof Promise);
     });
+    it('should return the same promise when a promise given', () => {
+        const p = Promise.resolve();
+        const ret = AsyncTestUtil.promisify(p);
+        assert.ok(p === ret);
+    });
 });

--- a/test/wait-resolveable.test.js
+++ b/test/wait-resolveable.test.js
@@ -3,10 +3,10 @@ const AsyncTestUtil = require('../dist/lib/index');
 
 
 describe('wait-resolveable.test.js', () => {
-    it('should wait time is over', async() => {
+    it('should wait time is over', async () => {
         await AsyncTestUtil.waitResolveable(100);
     });
-    it('should wait until manually resolved', async() => {
+    it('should wait until manually resolved', async () => {
         let resolved = null;
         const waiter = AsyncTestUtil.waitResolveable(10000);
         waiter.promise.then(x => {
@@ -15,5 +15,13 @@ describe('wait-resolveable.test.js', () => {
         waiter.resolve('foobar');
         await AsyncTestUtil.wait();
         assert.equal('foobar', resolved);
+    });
+    it('should timeout if the manually resolved late', async () => {
+        let resolved = null;
+        const ret = await AsyncTestUtil.waitResolveable(100);
+        ret.promise.then(x => resolved = x);
+        await AsyncTestUtil.wait(100 + 10);
+        ret.resolve('foobar');
+        assert.equal(undefined, resolved);
     });
 });


### PR DESCRIPTION
1. Add more tests
2. Make the `oneOfArrayNotInString` function shorter.

Before PR, ran the `npm run test` script, and all tests pass in both Node and Browser environments.